### PR TITLE
refactor handle redirects

### DIFF
--- a/unleash.go
+++ b/unleash.go
@@ -83,9 +83,7 @@ func (u *Unleash) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			logger.Info(fmt.Sprintf("Executing feature flag: %s", toggle.feature))
 			toggle.setHeaders(rw, req)
 			toggle.rewritePath(req)
-			if toggle.rewriteHost(rw, req) {
-				return
-			}
+			u.next, req = toggle.rewriteHost(u.next, req)
 			break
 		}
 	}

--- a/unleash.go
+++ b/unleash.go
@@ -77,17 +77,18 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 func (u *Unleash) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	logger.Info("Executing unleash plugin")
+	next := u.next
 	for _, toggle := range u.featureToggles {
 		logger.Info(fmt.Sprintf("Evaluating feature flag: %s", toggle.feature))
 		if toggle.appliesToRequest(req) {
 			logger.Info(fmt.Sprintf("Executing feature flag: %s", toggle.feature))
 			toggle.setHeaders(rw, req)
 			toggle.rewritePath(req)
-			u.next, req = toggle.rewriteHost(u.next, req)
+			next, req = toggle.rewriteHost(next, req)
 			break
 		}
 	}
-	u.next.ServeHTTP(rw, req)
+	next.ServeHTTP(rw, req)
 }
 
 func readConfig(config *Config) []FeatureToggle {


### PR DESCRIPTION
First refactor to handle redirects. We are now returning the new handler and the modified request.